### PR TITLE
refactor location

### DIFF
--- a/EatNow WatchKit Extension/GlanceController.m
+++ b/EatNow WatchKit Extension/GlanceController.m
@@ -67,7 +67,7 @@
                 }
             }
         }];
-    } forece:YES];
+    } ];
 }
 
 - (void)willActivate {

--- a/EatNow WatchKit Extension/InterfaceController.m
+++ b/EatNow WatchKit Extension/InterfaceController.m
@@ -47,7 +47,7 @@ DDLogLevel const ddLogLevel = DDLogLevelVerbose;
             }
             [WKInterfaceController reloadRootControllersWithNames:restaurants contexts:objests];
         }];
-    } forece:YES];
+    }];
 }
 @end
 

--- a/EatNow/Controllers/ENGetLocationViewController.m
+++ b/EatNow/Controllers/ENGetLocationViewController.m
@@ -47,7 +47,7 @@
             ENMainViewController *vc = [[UIStoryboard storyboardWithName:@"main" bundle:nil] instantiateViewControllerWithIdentifier:@"ENMainViewController"];
             [UIWindow mainWindow].rootViewController = vc;
         }
-    } forece:YES];
+    }];
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/EatNow/Controllers/ENMainViewController.m
+++ b/EatNow/Controllers/ENMainViewController.m
@@ -306,7 +306,7 @@
     self.showRestaurantCardTimer = [NSTimer scheduledTimerWithTimeInterval:0.1 target:self selector:@selector(onShowRestaurantTimer:) userInfo:nil repeats:YES];
 
     //load restaurants from server
-    [self searchNewRestaurantsForced:NO completion:^(NSArray *response, NSError *error) {
+    [self searchNewRestaurantsWithCompletion:^(NSArray *response, NSError *error) {
         if (!error) {
             self.needShowRestaurant = YES;
         }
@@ -448,7 +448,7 @@
     }
 
     //search for new
-    [self searchNewRestaurantsForced:YES completion:^(NSArray *response, NSError *error) {
+    [self searchNewRestaurantsWithCompletion:^(NSArray *response, NSError *error) {
         self.isSearchingFromServer = NO;
         
         //HACK: should remove error magic number
@@ -485,7 +485,7 @@
 }
 #pragma mark - Main methods
 
-- (void)searchNewRestaurantsForced:(BOOL)force completion:(void (^)(NSArray *response, NSError *error))block {
+- (void)searchNewRestaurantsWithCompletion:(void (^)(NSArray *response, NSError *error))block {
     NSDate *start = [NSDate date];
     @weakify(self);
     [self.locationManager getLocationWithCompletion:^(CLLocation *location, INTULocationAccuracy achievedAccuracy, ENLocationStatus status) {
@@ -512,7 +512,7 @@
             NSError *error = [NSError errorWithDomain:kEatNowErrorDomain code:-1 userInfo:nil];
             block(nil, error);
         }
-    } forece:force];
+    } ];
 }
 
 - (void)onShowRestaurantTimer:(id)sender {

--- a/EatNow/Server/ENLocationManager.h
+++ b/EatNow/Server/ENLocationManager.h
@@ -19,17 +19,12 @@ typedef void (^ENLocationCompletionBlock)(CLLocation *currentLocation, INTULocat
 @property (nonatomic, assign) ENLocationStatus locationStatus;
 GCD_SYNTHESIZE_SINGLETON_FOR_CLASS_HEADER(ENLocationManager)
 - (void)getLocationWithCompletion:(ENLocationCompletionBlock)completion;
-- (void)getLocationWithCompletion:(ENLocationCompletionBlock)completion forece:(BOOL)forceUpdate;
-- (void)cancelLocationRequest;
 
-/**
- *  return last fetched current location, if any.
- */
-+ (CLLocation *)cachedCurrentLocation;
 + (INTULocationServicesState)locationServicesState;
+
++ (CLLocation *)cachedCurrentLocation;
 
 + (void)registerLocationDeniedHandler:(void(^)(void))handler;
 + (void)registerLocationDisabledHanlder:(void (^)(void))handler;
 
-//+ (INTULocationServicesState)locationServicesState;
 @end

--- a/EatNow/Server/ENMapManager.m
+++ b/EatNow/Server/ENMapManager.m
@@ -29,53 +29,55 @@
 }
 
 - (void)findDirectionsTo:(CLLocation *)location completion:(void (^)(MKDirectionsResponse *response, NSError *error))block{
-	CLLocation *currentLocation = [ENLocationManager cachedCurrentLocation];
-	if (currentLocation) {
-		MKPlacemark *fromPlacemark = [[MKPlacemark alloc] initWithCoordinate:currentLocation.coordinate addressDictionary:nil];
-		MKMapItem *fromItem = [[MKMapItem alloc] initWithPlacemark:fromPlacemark];
-		MKPlacemark *pm = [[MKPlacemark alloc] initWithCoordinate:location.coordinate addressDictionary:nil];
-		MKMapItem *toItem   = [[MKMapItem alloc] initWithPlacemark:pm];
-		//routing
-		[self findDirectionsFrom:fromItem to:toItem completion:block];
-	}else{
-		if (block) {
-			NSError *err = [NSError errorWithDomain:@"EatNow" code:400 userInfo:@{NSLocalizedDescriptionKey: @"Current location not availble"}];
-			block(nil, err);
-		}
-	}
+    [[ENLocationManager sharedInstance] getLocationWithCompletion:^(CLLocation *currentLocation, INTULocationAccuracy achievedAccuracy, ENLocationStatus status) {
+        if (currentLocation) {
+            MKPlacemark *fromPlacemark = [[MKPlacemark alloc] initWithCoordinate:currentLocation.coordinate addressDictionary:nil];
+            MKMapItem *fromItem = [[MKMapItem alloc] initWithPlacemark:fromPlacemark];
+            MKPlacemark *pm = [[MKPlacemark alloc] initWithCoordinate:location.coordinate addressDictionary:nil];
+            MKMapItem *toItem   = [[MKMapItem alloc] initWithPlacemark:pm];
+            //routing
+            [self findDirectionsFrom:fromItem to:toItem completion:block];
+        }
+        else{
+            if (block) {
+                NSError *err = [NSError errorWithDomain:@"EatNow" code:400 userInfo:@{NSLocalizedDescriptionKey: @"Current location not availble"}];
+                block(nil, err);
+            }
+        }
+    }];
 }
 
 - (void)findDirectionsFrom:(MKMapItem *)source to:(MKMapItem *)destination completion:(void (^)(MKDirectionsResponse *response, NSError *error))block{
-	MKDirectionsRequest *request = [[MKDirectionsRequest alloc] init];
-	request.source = source;
-	request.destination = destination;
-	request.transportType = MKDirectionsTransportTypeWalking;
-	request.requestsAlternateRoutes = NO;
-	
-	MKDirections *directions = [[MKDirections alloc] initWithRequest:request];
-	
-	[directions calculateDirectionsWithCompletionHandler:^(MKDirectionsResponse *response, NSError *error) {
-		block(response, error);
-	}];
+    MKDirectionsRequest *request = [[MKDirectionsRequest alloc] init];
+    request.source = source;
+    request.destination = destination;
+    request.transportType = MKDirectionsTransportTypeWalking;
+    request.requestsAlternateRoutes = NO;
+    
+    MKDirections *directions = [[MKDirections alloc] initWithRequest:request];
+    
+    [directions calculateDirectionsWithCompletionHandler:^(MKDirectionsResponse *response, NSError *error) {
+        block(response, error);
+    }];
 }
 
 - (void)estimatedWalkingTimeToLocation:(CLLocation *)location completion:(void (^)(NSTimeInterval length, NSError *error))block{
-	[self findDirectionsTo:location completion:^(MKDirectionsResponse *response, NSError *error) {
-		
-		if (error) {
-			DDLogError(@"error:%@", error);
-			if (block) {
-				block(NSTimeIntervalSince1970, error);
-			}
-		}
-		else {
-			
-			MKRoute *route = response.routes[0];
-			if (block) {
-				block(route.expectedTravelTime, error);
-			}
-		}
-	}];
+    [self findDirectionsTo:location completion:^(MKDirectionsResponse *response, NSError *error) {
+        
+        if (error) {
+            DDLogError(@"error:%@", error);
+            if (block) {
+                block(NSTimeIntervalSince1970, error);
+            }
+        }
+        else {
+            
+            MKRoute *route = response.routes[0];
+            if (block) {
+                block(route.expectedTravelTime, error);
+            }
+        }
+    }];
 }
 
 #pragma mark - MAP management
@@ -86,50 +88,52 @@
         [_repeatTimer invalidate];
         return;
     }
-	CLLocation *destination = restaurant.location;
-	
-	if (self.map.annotations.count == 0) {
-		[self addAnnotationForRestaurant:restaurant];
-	}
-	
+    CLLocation *destination = restaurant.location;
+    
+    if (self.map.annotations.count == 0) {
+        [self addAnnotationForRestaurant:restaurant];
+    }
+    
     [self findDirectionsTo:destination completion:^(MKDirectionsResponse *response, NSError *error) {
-        CLLocation *origin = [ENLocationManager cachedCurrentLocation];
+        [[ENLocationManager sharedInstance] getLocationWithCompletion:^(CLLocation *currentLocation, INTULocationAccuracy achievedAccuracy, ENLocationStatus status) {
+            CLLocation *origin = currentLocation;
+            if (!response) {
+                //[ENUtil showFailureHUBWithString:@"Please retry"];
+                DDLogError(@"error:%@", error);
+                if (block) {
+                    block(-1, error);
+                }
+            }
+            else {
+                
+                //add overlay
+                MKRoute *route = response.routes[0];
+                [self.map removeOverlays:_map.overlays];
+                [self.map addOverlay:route.polyline level:MKOverlayLevelAboveRoads];
+                
+                if (self.firstTimeRoute) {
+                    self.firstTimeRoute = NO;
+                    //change region
+                    CLLocationCoordinate2D from = origin.coordinate;
+                    CLLocation *center = [[CLLocation alloc] initWithLatitude:(from.latitude + destination.coordinate.latitude)/2 longitude:(from.longitude + destination.coordinate.longitude)/2];
+                    MKCoordinateSpan span = MKCoordinateSpanMake(fabs(from.latitude - destination.coordinate.latitude)*1.5, fabs(from.longitude - destination.coordinate.longitude)*1.5);
+                    [self.map setRegion:MKCoordinateRegionMake(center.coordinate, span) animated:YES];
+                }
+                
+                if (block) {
+                    block(route.expectedTravelTime, error);
+                }
+                
+                if (updateInterval > 0) {
+                    _repeatTimer = [NSTimer bk_scheduledTimerWithTimeInterval:updateInterval block:^(NSTimer *timer) {
+                        [[ENLocationManager shared] getLocationWithCompletion:^(CLLocation *loc, INTULocationAccuracy achievedAccuracy, ENLocationStatus status) {
+                            [self routeToRestaurant:restaurant repeat:updateInterval completion:block];
+                        }];
+                    } repeats:NO];
+                }
+            }
+        }];
         
-        if (!response) {
-            //[ENUtil showFailureHUBWithString:@"Please retry"];
-            DDLogError(@"error:%@", error);
-            if (block) {
-                block(-1, error);
-            }
-        }
-        else {
-            
-            //add overlay
-            MKRoute *route = response.routes[0];
-            [self.map removeOverlays:_map.overlays];
-            [self.map addOverlay:route.polyline level:MKOverlayLevelAboveRoads];
-            
-            if (self.firstTimeRoute) {
-                self.firstTimeRoute = NO;
-                //change region
-                CLLocationCoordinate2D from = origin.coordinate;
-                CLLocation *center = [[CLLocation alloc] initWithLatitude:(from.latitude + destination.coordinate.latitude)/2 longitude:(from.longitude + destination.coordinate.longitude)/2];
-                MKCoordinateSpan span = MKCoordinateSpanMake(fabs(from.latitude - destination.coordinate.latitude)*1.5, fabs(from.longitude - destination.coordinate.longitude)*1.5);
-                [self.map setRegion:MKCoordinateRegionMake(center.coordinate, span) animated:YES];
-            }
-            
-            if (block) {
-                block(route.expectedTravelTime, error);
-            }
-            
-            if (updateInterval > 0) {
-                _repeatTimer = [NSTimer bk_scheduledTimerWithTimeInterval:updateInterval block:^(NSTimer *timer) {
-                    [[ENLocationManager shared] getLocationWithCompletion:^(CLLocation *loc, INTULocationAccuracy achievedAccuracy, ENLocationStatus status) {
-                        [self routeToRestaurant:restaurant repeat:updateInterval completion:block];
-                    } forece:YES];
-                } repeats:NO];
-            }
-        }
     }];
 }
 


### PR DESCRIPTION
- subscribe will not make it faster as far as I can tell. I've removed related methods, please see documentation of INTULocationManager
- currentLocation caching is removed, INTULocationManager already has caching
- cachedLocation is redone, it should only be used for logging, it will not provide accurate result, or result at all.
- ENLocationStatus should be removed, I've created a method enLocationStatusFromINTULocationStatus to transform the type. the logic was extract from old code, but I don't see any good reason to introduce ENLocationStatus. some part I don't understand, like why when status is INTULocationStatusTimedOut, it reports ENLocationStatusGotLocation?
